### PR TITLE
fixed card props - send just needed to avoid dom leak

### DIFF
--- a/src/components/Cart/Cart.jsx
+++ b/src/components/Cart/Cart.jsx
@@ -10,7 +10,7 @@ import {
 } from './Cart.styles';
 import { CART_TEXT} from '../../constants/hardText.js';
 import { BUTTON_VARIANTS } from '../../constants/types.js';
-import ProductCard from '../Product/ProductCard';
+import ProductCard from '../Product/ProductCard/ProductCard.jsx';
 import ActionButton from '../shared/Button/ActionButton.jsx';
 import CustomDivider from '../shared/Divider/CustomDivider.jsx';
 import SharedGrid from '../shared/Grid/SharedGrid';

--- a/src/components/Cart/Cart.jsx
+++ b/src/components/Cart/Cart.jsx
@@ -8,7 +8,7 @@ import {
   RemoveButtonWrapper,
   CartItemWrapper,
 } from './Cart.styles';
-import { CART_TEXT} from '../../constants/hardText.js';
+import { CART_TEXT } from '../../constants/hardText.js';
 import { BUTTON_VARIANTS } from '../../constants/types.js';
 import ProductCard from '../Product/ProductCard/ProductCard.jsx';
 import ActionButton from '../shared/Button/ActionButton.jsx';
@@ -51,36 +51,34 @@ const Cart = ({
       ) : (
         <>
           <SharedGrid
-            items={validItems.map(
-              ({ id, images, name, price, rating,  }) => ({
-                id,
-                images,
-                name,
-                price,
-                rating,
-                description: (
-                  <CartItemWrapper>
-                    <ProductCard
-                      id={id}
-                      images={images}
-                      name={name}
-                      price={price}
-                      rating={rating}
-                      onSelect={() => {}}
-                      disabled
-                    />
-                    <RemoveButtonWrapper>
-                      <ActionButton
-                        onClick={() => handleItemRemove(id)}
-                        styleType={BUTTON_VARIANTS.OUTLINED}
-                      >
-                        {CART_TEXT.REMOVE_BUTTON}
-                      </ActionButton>
-                    </RemoveButtonWrapper>
-                  </CartItemWrapper>
-                ),
-              }),
-            )}
+            items={validItems.map(({ id, images, name, price, rating }) => ({
+              id,
+              images,
+              name,
+              price,
+              rating,
+              description: (
+                <CartItemWrapper>
+                  <ProductCard
+                    id={id}
+                    images={images}
+                    name={name}
+                    price={price}
+                    rating={rating}
+                    onSelect={() => {}}
+                    disabled
+                  />
+                  <RemoveButtonWrapper>
+                    <ActionButton
+                      onClick={() => handleItemRemove(id)}
+                      styleType={BUTTON_VARIANTS.OUTLINED}
+                    >
+                      {CART_TEXT.REMOVE_BUTTON}
+                    </ActionButton>
+                  </RemoveButtonWrapper>
+                </CartItemWrapper>
+              ),
+            }))}
             columns={1}
             spacing={2}
             justifyContent="center"
@@ -98,7 +96,11 @@ const Cart = ({
           {!isLoggedIn && (
             <EmptyCartText>{CART_TEXT.CART_LOGIN_REQUIRED}</EmptyCartText>
           )}
-          <ActionButton onClick={onContinue} disabled={!canPurchase} styleType={BUTTON_VARIANTS.FILLED}>
+          <ActionButton
+            onClick={onContinue}
+            disabled={!canPurchase}
+            styleType={BUTTON_VARIANTS.FILLED}
+          >
             {CART_TEXT.CART_CONTINUE}
           </ActionButton>
         </>

--- a/src/components/Cart/Cart.jsx
+++ b/src/components/Cart/Cart.jsx
@@ -52,8 +52,7 @@ const Cart = ({
         <>
           <SharedGrid
             items={validItems.map(
-              ({ id, images, name, price, rating, ...rest }) => ({
-                ...rest,
+              ({ id, images, name, price, rating,  }) => ({
                 id,
                 images,
                 name,

--- a/src/components/Product/ProductCard.jsx
+++ b/src/components/Product/ProductCard.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { CardContent, CardActionArea } from '@mui/material';
 
 import { StyledCard } from './Product.styled.js';
-import { UI_TEXT } from '../../constants/hardText.js';
 import { addSignShekel  } from '../../utils/converting.js';
 import { SharedImage } from '../shared/Image/SharedImage.jsx';
 import SharedTypography from '../shared/Text/SharedTypography.jsx';
@@ -14,10 +13,9 @@ const ProductCard = ({
   name,
   price,
   onSelect,
-  ...props
 }) => {
   return (
-    <StyledCard {...props}>
+    <StyledCard>
       <CardActionArea onClick={() => onSelect(id)}>
         <SharedImage src={images} alt={name} />
 

--- a/src/components/Product/ProductCard/ProductCard.jsx
+++ b/src/components/Product/ProductCard/ProductCard.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { CardContent, CardActionArea } from '@mui/material';
 
-import { StyledCard } from './Product.styled.js';
-import { addSignShekel  } from '../../utils/converting.js';
-import { SharedImage } from '../shared/Image/SharedImage.jsx';
-import SharedTypography from '../shared/Text/SharedTypography.jsx';
+import { addSignShekel  } from '../../../utils/converting.js';
+import { SharedImage } from '../../shared/Image/SharedImage.jsx';
+import SharedTypography from '../../shared/Text/SharedTypography.jsx';
+import { StyledCard } from '../Product.styled.js';
 
 const ProductCard = ({
   id,

--- a/src/components/Product/ProductCard/productCard.utils.js
+++ b/src/components/Product/ProductCard/productCard.utils.js
@@ -1,0 +1,9 @@
+export function getProductCardProps(product, onSelect) {
+  return {
+    id: product.id,
+    images: product.images,
+    name: product.name,
+    price: product.price,
+    onSelect,
+  };
+}

--- a/src/components/ProductCarousel/ProductCarousel.jsx
+++ b/src/components/ProductCarousel/ProductCarousel.jsx
@@ -12,7 +12,8 @@ import {
 } from './Carousel.constants.js';
 import { CarouselWrapper } from './ProductCarousel.styled';
 import { ROUTES } from '../../constants/routes.constants.js';
-import ProductCard from '../Product/ProductCard';
+import ProductCard from '../Product/ProductCard/ProductCard.jsx';
+import { getProductCardProps } from '../Product/ProductCard/productCard.utils.js';
 
 const ProductCarousel = ({ products }) => {
   const settings = {
@@ -39,13 +40,7 @@ const ProductCarousel = ({ products }) => {
       <Slider {...settings}>
         {products.map((product) => (
           <div key={product.id}>
-            <ProductCard
-              id={product.id}
-              images={product.images}
-              name={product.name}
-              price={product.price}
-              onSelect={handleProductClick}
-            />
+            <ProductCard {...getProductCardProps(product, handleProductClick)} />
           </div>
         ))}
       </Slider>

--- a/src/components/ProductCarousel/ProductCarousel.jsx
+++ b/src/components/ProductCarousel/ProductCarousel.jsx
@@ -39,7 +39,13 @@ const ProductCarousel = ({ products }) => {
       <Slider {...settings}>
         {products.map((product) => (
           <div key={product.id}>
-            <ProductCard {...product} onSelect={handleProductClick} />
+            <ProductCard
+              id={product.id}
+              images={product.images}
+              name={product.name}
+              price={product.price}
+              onSelect={handleProductClick}
+            />
           </div>
         ))}
       </Slider>

--- a/src/pages/Products/ProductListPage.jsx
+++ b/src/pages/Products/ProductListPage.jsx
@@ -5,7 +5,8 @@ import { useNavigate } from 'react-router-dom';
 import { CircularProgress, Grid } from '@mui/material';
 
 import { containerStyle, spinnerStyle } from './ProductListPage.styled.js';
-import ProductCard from '../../components/Product/ProductCard.jsx';
+import ProductCard from '../../components/Product/ProductCard/ProductCard.jsx';
+import { getProductCardProps } from '../../components/Product/ProductCard/productCard.utils.js';
 import SharedTypography from '../../components/shared/Text/SharedTypography.jsx';
 import { ERROR_MESSAGES } from '../../constants/errorMessages.js';
 import { ROUTES } from '../../constants/routes.constants.js';
@@ -37,13 +38,7 @@ const ProductListPage = () => {
     <Grid container spacing={3} style={containerStyle}>
       {products.map((p) => (
         <Grid key={p.id}>
-          <ProductCard
-            id={p.id}
-            images={p.images}
-            name={p.name}
-            price={p.price}
-            onSelect={handleSelect}
-          />
+          <ProductCard {...getProductCardProps(p, handleSelect)} />
         </Grid>
       ))}
     </Grid>

--- a/src/pages/Products/ProductListPage.jsx
+++ b/src/pages/Products/ProductListPage.jsx
@@ -37,7 +37,13 @@ const ProductListPage = () => {
     <Grid container spacing={3} style={containerStyle}>
       {products.map((p) => (
         <Grid key={p.id}>
-          <ProductCard {...p} onSelect={handleSelect} />
+          <ProductCard
+            id={p.id}
+            images={p.images}
+            name={p.name}
+            price={p.price}
+            onSelect={handleSelect}
+          />
         </Grid>
       ))}
     </Grid>


### PR DESCRIPTION
Removed spread props (...props, ...rest) from ProductCard to prevent unintended props from leaking into the DOM. Only explicitly required props are now passed to ensure cleaner and safer component usage.